### PR TITLE
MM-17: (feat) Get and update user language

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vidal-community/ng2-sesame",
-  "version": "14.0.7-7",
+  "version": "14.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@vidal-community/ng2-sesame",
-      "version": "14.0.7-7",
+      "version": "14.0.7",
       "license": "MIT",
       "dependencies": {
         "core-js": "3.6.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vidal-community/ng2-sesame",
-  "version": "14.0.2",
+  "version": "14.0.7-7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@vidal-community/ng2-sesame",
-      "version": "14.0.2",
+      "version": "14.0.7-7",
       "license": "MIT",
       "dependencies": {
         "core-js": "3.6.5",
@@ -30,6 +30,7 @@
         "@angular/platform-server": "^14.0.4",
         "@angular/router": "14.0.4",
         "@types/jasmine": "~3.6.0",
+        "@types/jsrsasign": "^10.5.4",
         "@types/node": "~14.6.3",
         "codelyzer": "^6.0.0",
         "jasmine-core": "~3.6.0",
@@ -3229,6 +3230,12 @@
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
+      "dev": true
+    },
+    "node_modules/@types/jsrsasign": {
+      "version": "10.5.4",
+      "resolved": "https://registry.npmjs.org/@types/jsrsasign/-/jsrsasign-10.5.4.tgz",
+      "integrity": "sha512-05S2f4lGaWgCwFHsa3OEirc4VJf/sJRfhofzxUbuFbmm6NbffPXZrnJqquQAtS3g4C8Z0L9NHgW0znmtDxNoTQ==",
       "dev": true
     },
     "node_modules/@types/mime": {
@@ -17215,6 +17222,12 @@
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
+      "dev": true
+    },
+    "@types/jsrsasign": {
+      "version": "10.5.4",
+      "resolved": "https://registry.npmjs.org/@types/jsrsasign/-/jsrsasign-10.5.4.tgz",
+      "integrity": "sha512-05S2f4lGaWgCwFHsa3OEirc4VJf/sJRfhofzxUbuFbmm6NbffPXZrnJqquQAtS3g4C8Z0L9NHgW0znmtDxNoTQ==",
       "dev": true
     },
     "@types/mime": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vidal-community/ng2-sesame",
-  "version": "14.0.7-7",
+  "version": "14.0.7",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vidal-community/ng2-sesame",
-  "version": "14.0.2",
+  "version": "14.0.7-7",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -42,6 +42,7 @@
     "@angular/platform-server": "^14.0.4",
     "@angular/router": "14.0.4",
     "@types/jasmine": "~3.6.0",
+    "@types/jsrsasign": "^10.5.4",
     "@types/node": "~14.6.3",
     "codelyzer": "^6.0.0",
     "jasmine-core": "~3.6.0",

--- a/src/lib/language.model.ts
+++ b/src/lib/language.model.ts
@@ -1,0 +1,4 @@
+export interface Language {
+  code: string;
+  label: string;
+}

--- a/src/lib/sesame-http.service.ts
+++ b/src/lib/sesame-http.service.ts
@@ -1,13 +1,9 @@
-import {Inject, Injectable, InjectionToken} from '@angular/core';
+import {Inject, Injectable} from '@angular/core';
 import {Observable, of} from 'rxjs';
 import {HttpClient, HttpHeaders} from '@angular/common/http';
 import {catchError} from 'rxjs/operators';
-
-export const SESAME_CONFIG = new InjectionToken('sesame.config');
-
-export interface SesameConfig {
-  apiEndpoint: string;
-}
+import {Language} from './language.model';
+import {SESAME_CONFIG, SesameConfig} from './sesame.service';
 
 @Injectable({
   providedIn: 'root'
@@ -15,7 +11,7 @@ export interface SesameConfig {
 export class SesameHttpService {
 
   constructor(private http: HttpClient,
-              @Inject(SESAME_CONFIG) private sesameConfig: any) {
+              @Inject(SESAME_CONFIG) private sesameConfig: SesameConfig) {
   }
 
   getPem(): Observable<string> {
@@ -34,6 +30,24 @@ export class SesameHttpService {
         withCredentials: true, headers,
         responseType: 'text'
       });
+  }
+
+  fetchLanguage(): Observable<Language> {
+    return this.http
+      .get<Language>(`${this.sesameConfig.apiEndpoint}/user/language`, {
+        withCredentials: true
+      });
+  }
+
+  public updateLanguage(language: Language): Observable<Language> {
+    return this.http
+      .post<Language>(`${this.sesameConfig.apiEndpoint}/user/language/save/${language.code}`, {}, {
+        withCredentials: true
+      });
+  }
+
+  public getAllLanguages(): Observable<Language[]> {
+    return this.http.get<Language[]>(`${this.sesameConfig.apiEndpoint}/language/all`);
   }
 
   public faceUrl(login: string): Observable<string> {

--- a/src/lib/sesame.module.ts
+++ b/src/lib/sesame.module.ts
@@ -1,5 +1,5 @@
 import {ModuleWithProviders, NgModule} from '@angular/core';
-import {JwtUtils, SESAME_CONFIG, SesameService} from './sesame.service';
+import {JwtUtils, SesameService, SESAME_CONFIG} from './sesame.service';
 import {HttpClientModule} from '@angular/common/http';
 
 @NgModule({


### PR DESCRIPTION
We added user language in sesame server.

In order to use it via the toolbar, we allow ng-sesame to :

- retrieve user language during login
- update user language via a dedicated service

Because the language is pertinent only when user is logged, we stored it in UserInfo class.

We dediced not to store it in jwtToken because user information is not related to authentication concerns.