### PR TITLE
Add alpha2 code to user language

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ To publish a pre-release, run:
 To publish a release, run:
 
     npm run major-release
-    
+or   
+    npm run minor-release
+
 It will increase version with chosen strategy, then build and package your 
 local workspace, and finally publish it on `npm`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vidal-community/ng2-sesame",
-  "version": "14.0.14-1",
+  "version": "14.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@vidal-community/ng2-sesame",
-      "version": "14.0.14-1",
+      "version": "14.1.0",
       "license": "MIT",
       "dependencies": {
         "core-js": "3.6.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vidal-community/ng2-sesame",
-  "version": "14.0.13",
+  "version": "14.0.14-1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@vidal-community/ng2-sesame",
-      "version": "14.0.13",
+      "version": "14.0.14-1",
       "license": "MIT",
       "dependencies": {
         "core-js": "3.6.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vidal-community/ng2-sesame",
-  "version": "14.0.14-1",
+  "version": "14.1.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vidal-community/ng2-sesame",
-  "version": "14.0.13",
+  "version": "14.0.14-1",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -10,13 +10,15 @@
     "test": "ng test --watch false",
     "lint": "ng lint",
     "prepare-prerelease": "npm version prerelease --no-git-tag-version && npm i",
-    "prepare-release": "npm version major && npm i",
+    "prepare-major-release": "npm version major && npm i",
+    "prepare-minor-release": "npm version minor && npm i",
     "build": "ng build",
     "package": "cd dist/@vidal-community/ng2-sesame && npm pack",
     "publish": "npm publish dist/@vidal-community/ng2-sesame/vidal-community-ng2-sesame-*.tgz",
     "build-and-publish": "ng build && npm run package && npm run publish",
     "prerelease": "npm run prepare-prerelease && npm run build-and-publish",
-    "major-release": "npm run prepare-release && npm run build-and-publish"
+    "major-release": "npm run prepare-major-release && npm run build-and-publish",
+    "minor-release": "npm run prepare-minor-release && npm run build-and-publish"
   },
   "types": "./index.d.ts",
   "main": "./index.js",

--- a/src/lib/language.model.ts
+++ b/src/lib/language.model.ts
@@ -1,4 +1,5 @@
 export interface Language {
-  code: string;
+  code: string; // alpha3code (ISO 639-2). We do not rename it for backward compatibility
+  alpha2Code: string;
   label: string;
 }


### PR DESCRIPTION
    Add alpha2 code to user language
    
    This commit is backwards compatibl. We just add an ISO639-1  alpha2code. The default code is ISO 639-2 alpha-3.
    
    Depending on projects, we may need one or another. It will be easier to use the most pertinent code depending on context
